### PR TITLE
fixed SSLv3 version

### DIFF
--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -28,7 +28,7 @@ module RubyPushNotifications
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
       # @return [APNSConnection]. The recently stablished connection.
       def self.open(cert, sandbox, pass = nil)
-        ctx = OpenSSL::SSL::SSLContext.new(:TLSv1_2)
+        ctx = OpenSSL::SSL::SSLContext.new(:TLSv1)
         ctx.key = OpenSSL::PKey::RSA.new cert, pass
         ctx.cert = OpenSSL::X509::Certificate.new cert
 

--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -28,7 +28,7 @@ module RubyPushNotifications
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
       # @return [APNSConnection]. The recently stablished connection.
       def self.open(cert, sandbox, pass = nil)
-        ctx = OpenSSL::SSL::SSLContext.new
+        ctx = OpenSSL::SSL::SSLContext.new(:TLSv1_2)
         ctx.key = OpenSSL::PKey::RSA.new cert, pass
         ctx.cert = OpenSSL::X509::Certificate.new cert
 


### PR DESCRIPTION
Fix for APN connection failing with message `SSL_connect SYSCALL returned=5 errno=0 state=SSLv3 read server session ticket A`