### PR TITLE
Provide a way to set timeouts for GCM, APNS and MPNS + sane defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - "2.2.0"
   - "2.1.5"
   - "2.0.0"
-  - "1.9.3"
 env: CODECLIMATE_REPO_TOKEN=efdb12c380287a25b2b26362aa710a9b59020122cbe4edecf0d353bf50e0046a
 notifications:
   webhooks:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-push-notifications (0.5.0)
+    ruby-push-notifications (1.0.0)
       builder (~> 3.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-push-notifications (0.4.0)
+    ruby-push-notifications (0.5.0)
       builder (~> 3.0)
 
 GEM
@@ -66,4 +66,4 @@ DEPENDENCIES
   webmock (~> 1.20)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/examples/apns.rb
+++ b/examples/apns.rb
@@ -14,7 +14,7 @@ notification = RubyPushNotifications::APNS::APNSNotification.new tokens, { aps: 
 
 pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password) # enter the password if present
 # Connect timeout defaults to 30s
-# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, connect_timeout: { 20 })
+# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { connect_timeout: 20 })
 
 pusher.push [notification]
 p 'Notification sending results:'

--- a/examples/apns.rb
+++ b/examples/apns.rb
@@ -13,6 +13,9 @@ password = nil # optional password for .pem file
 notification = RubyPushNotifications::APNS::APNSNotification.new tokens, { aps: { alert: 'Hello APNS World!', sound: 'true', badge: 1 } }
 
 pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password) # enter the password if present
+# Connect timeout defaults to 30s
+# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, connect_timeout: { 20 })
+
 pusher.push [notification]
 p 'Notification sending results:'
 p "Success: #{notification.success}, Failed: #{notification.failed}"

--- a/examples/gcm.rb
+++ b/examples/gcm.rb
@@ -12,6 +12,9 @@ registration_ids = [
 notification = RubyPushNotifications::GCM::GCMNotification.new registration_ids, { text: 'Hello GCM World!' }
 
 pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key"
+# Open and read timeouts default to 30s
+# pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { open_timeout: 10, read_timeout: 10 }
+
 pusher.push [notification]
 p 'Notification sending results:'
 p "Success: #{notification.success}, Failed: #{notification.failed}"

--- a/examples/mpns.rb
+++ b/examples/mpns.rb
@@ -13,6 +13,8 @@ device_urls = [
 notification = RubyPushNotifications::MPNS::MPNSNotification.new device_urls, { title: 'Title', message: 'Hello MPNS World!', type: :toast }
 
 pusher = RubyPushNotifications::MPNS::MPNSPusher.new
+# Open and read timeouts default to 30s
+# pusher = RubyPushNotifications::MPNS::MPNSPusher.new optional_certificate, { open_timeout: 10, read_timeout: 10 }
 pusher.push [notification]
 p 'Notification sending results:'
 p "Success: #{notification.success}, Failed: #{notification.failed}"

--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -26,14 +26,16 @@ module RubyPushNotifications
       #
       # @param cert [String]. Contents of the PEM encoded certificate
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
+      # @param optional pass [String]. Passphrase for the certificate.
+      # @param optional options [Hash]. Options for the TCP socket
       # @return [APNSConnection]. The recently stablished connection.
-      def self.open(cert, sandbox, pass = nil)
+      def self.open(cert, sandbox, pass = nil, options = {})
         ctx = OpenSSL::SSL::SSLContext.new
         ctx.key = OpenSSL::PKey::RSA.new cert, pass
         ctx.cert = OpenSSL::X509::Certificate.new cert
 
         h = host sandbox
-        socket = TCPSocket.new h, APNS_PORT
+        socket = Socket.tcp h, APNS_PORT, nil, nil, connect_timeout: options.fetch(:connect_timeout, 30)
         ssl = OpenSSL::SSL::SSLSocket.new socket, ctx
         ssl.connect
 

--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -26,8 +26,9 @@ module RubyPushNotifications
       #
       # @param cert [String]. Contents of the PEM encoded certificate
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
-      # @param optional pass [String]. Passphrase for the certificate.
-      # @param optional options [Hash]. Options for the TCP socket
+      # @param pass [String] optional. Passphrase for the certificate.
+      # @param options [Hash] optional. Options for #open. Currently supports:
+      #   * connect_timeout [Integer]: how long the socket will wait for when opening the APNS socket. Defaults to 30.
       # @return [APNSConnection]. The recently stablished connection.
       def self.open(cert, sandbox, pass = nil, options = {})
         ctx = OpenSSL::SSL::SSLContext.new

--- a/lib/ruby-push-notifications/apns/apns_pusher.rb
+++ b/lib/ruby-push-notifications/apns/apns_pusher.rb
@@ -15,7 +15,8 @@ module RubyPushNotifications
 
       # @param certificate [String]. The PEM encoded APNS certificate.
       # @param sandbox [Boolean]. Whether the certificate is an APNS sandbox or not.
-      # @param optional options [Hash]. Options for the TCP socket.
+      # @param options [Hash] optional. Options for APNSPusher. Currently supports:
+      #   * connect_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       def initialize(certificate, sandbox, password = nil, options = {})
         @certificate = certificate
         @pass = password

--- a/lib/ruby-push-notifications/apns/apns_pusher.rb
+++ b/lib/ruby-push-notifications/apns/apns_pusher.rb
@@ -63,7 +63,7 @@ module RubyPushNotifications
               results.slice! err[2]..-1
               results << err[1]
               i = err[2]
-              conn = APNSConnection.open @certificate, @sandbox, @pass
+              conn = APNSConnection.open @certificate, @sandbox, @pass, @options
             end
           else
             results << NO_ERROR_STATUS_CODE

--- a/lib/ruby-push-notifications/apns/apns_pusher.rb
+++ b/lib/ruby-push-notifications/apns/apns_pusher.rb
@@ -15,10 +15,12 @@ module RubyPushNotifications
 
       # @param certificate [String]. The PEM encoded APNS certificate.
       # @param sandbox [Boolean]. Whether the certificate is an APNS sandbox or not.
-      def initialize(certificate, sandbox, password = nil)
+      # @param optional options [Hash]. Options for the TCP socket.
+      def initialize(certificate, sandbox, password = nil, options = {})
         @certificate = certificate
         @pass = password
         @sandbox = sandbox
+        @options = options
       end
 
       # Pushes the notifications.
@@ -31,7 +33,7 @@ module RubyPushNotifications
       #
       # @param notifications [Array]. All the APNSNotifications to be sent.
       def push(notifications)
-        conn = APNSConnection.open @certificate, @sandbox, @pass
+        conn = APNSConnection.open @certificate, @sandbox, @pass, @options
 
         binaries = notifications.each_with_object([]) do |notif, binaries|
           notif.each_message(binaries.count) do |msg|

--- a/lib/ruby-push-notifications/gcm/gcm_connection.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_connection.rb
@@ -27,8 +27,9 @@ module RubyPushNotifications
       # @param notification [String]. The text to POST
       # @param key [String]. The GCM sender id to use
       #    (https://developer.android.com/google/gcm/gcm.html#senderid)
+      # @param optional options [Hash]. Options for the HTTP connection.
       # @return [GCMResponse]. The GCMResponse that encapsulates the received response
-      def self.post(notification, key)
+      def self.post(notification, key, options = {})
         headers = {
             CONTENT_TYPE_HEADER => JSON_CONTENT_TYPE,
             AUTHORIZATION_HEADER => "key=#{key}"
@@ -38,6 +39,8 @@ module RubyPushNotifications
         http = Net::HTTP.new url.host, url.port
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.open_timeout = options.fetch(:open_timeout, 30)
+        http.read_timeout = options.fetch(:read_timeout, 30)
 
         response = http.post url.path, notification, headers
 

--- a/lib/ruby-push-notifications/gcm/gcm_connection.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_connection.rb
@@ -27,7 +27,9 @@ module RubyPushNotifications
       # @param notification [String]. The text to POST
       # @param key [String]. The GCM sender id to use
       #    (https://developer.android.com/google/gcm/gcm.html#senderid)
-      # @param optional options [Hash]. Options for the HTTP connection.
+      # @param options [Hash] optional. Options for #post. Currently supports:
+      #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
+      #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       # @return [GCMResponse]. The GCMResponse that encapsulates the received response
       def self.post(notification, key, options = {})
         headers = {

--- a/lib/ruby-push-notifications/gcm/gcm_pusher.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_pusher.rb
@@ -11,8 +11,10 @@ module RubyPushNotifications
       #
       # @param key [String]. GCM sender id to use
       #   ((https://developer.android.com/google/gcm/gcm.html#senderid))
-      def initialize(key)
+      # @param optional options [Hash]. Options for the HTTP connection.
+      def initialize(key, options = {})
         @key = key
+        @options = options
       end
 
       # Actually pushes the given notifications.
@@ -22,7 +24,7 @@ module RubyPushNotifications
       # @param notifications [Array]. Array of GCMNotification to send.
       def push(notifications)
         notifications.each do |notif|
-          notif.results = GCMConnection.post notif.as_gcm_json, @key
+          notif.results = GCMConnection.post notif.as_gcm_json, @key, @options
         end
       end
     end

--- a/lib/ruby-push-notifications/gcm/gcm_pusher.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_pusher.rb
@@ -11,7 +11,9 @@ module RubyPushNotifications
       #
       # @param key [String]. GCM sender id to use
       #   ((https://developer.android.com/google/gcm/gcm.html#senderid))
-      # @param optional options [Hash]. Options for the HTTP connection.
+      # @param options [Hash] optional. Options for GCMPusher. Currently supports:
+      #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
+      #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       def initialize(key, options = {})
         @key = key
         @options = options

--- a/lib/ruby-push-notifications/mpns/mpns_connection.rb
+++ b/lib/ruby-push-notifications/mpns/mpns_connection.rb
@@ -33,8 +33,10 @@ module RubyPushNotifications
       # submit the given notifications.
       #
       # @param n [MPNSNotification]. The notification object to POST
-      # @param optional cert [String]. Contents of the PEM encoded certificate
-      # @param optional options [Hash]. Options for the HTTP connection.
+      # @param cert [String] optional. Contents of the PEM encoded certificate.
+      # @param options [Hash] optional. Options for GCMPusher. Currently supports:
+      #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
+      #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       # @return [Array]. The response of post
       # (http://msdn.microsoft.com/pt-br/library/windows/apps/ff941099)
       def self.post(n, cert = nil, options = {})

--- a/lib/ruby-push-notifications/mpns/mpns_connection.rb
+++ b/lib/ruby-push-notifications/mpns/mpns_connection.rb
@@ -34,14 +34,17 @@ module RubyPushNotifications
       #
       # @param n [MPNSNotification]. The notification object to POST
       # @param optional cert [String]. Contents of the PEM encoded certificate
+      # @param optional options [Hash]. Options for the HTTP connection.
       # @return [Array]. The response of post
       # (http://msdn.microsoft.com/pt-br/library/windows/apps/ff941099)
-      def self.post(n, cert = nil)
+      def self.post(n, cert = nil, options = {})
         headers = build_headers(n.data[:type], n.data[:delay])
         body = n.as_mpns_xml
         responses = []
         n.each_device do |url|
           http = Net::HTTP.new url.host, url.port
+          http.open_timeout = options.fetch(:open_timeout, 30)
+          http.read_timeout = options.fetch(:read_timeout, 30)
           if cert && url.scheme == 'https'
             http.use_ssl = true
             http.verify_mode = OpenSSL::SSL::VERIFY_PEER

--- a/lib/ruby-push-notifications/mpns/mpns_pusher.rb
+++ b/lib/ruby-push-notifications/mpns/mpns_pusher.rb
@@ -9,9 +9,11 @@ module RubyPushNotifications
       # Initializes the MPNSPusher
       #
       # @param certificate [String]. The PEM encoded MPNS certificate.
+      # @param optional options [Hash]. Options for the HTTP connection.
       # (http://msdn.microsoft.com/pt-br/library/windows/apps/ff941099)
-      def initialize(certificate = nil)
+      def initialize(certificate = nil, options = {})
         @certificate = certificate
+        @options = options
       end
 
       # Actually pushes the given notifications.
@@ -21,7 +23,7 @@ module RubyPushNotifications
       # @param notifications [Array]. Array of MPNSNotification to send.
       def push(notifications)
         notifications.each do |notif|
-          notif.results = MPNSConnection.post notif, @certificate
+          notif.results = MPNSConnection.post notif, @certificate, options
         end
       end
     end

--- a/lib/ruby-push-notifications/mpns/mpns_pusher.rb
+++ b/lib/ruby-push-notifications/mpns/mpns_pusher.rb
@@ -23,7 +23,7 @@ module RubyPushNotifications
       # @param notifications [Array]. Array of MPNSNotification to send.
       def push(notifications)
         notifications.each do |notif|
-          notif.results = MPNSConnection.post notif, @certificate, options
+          notif.results = MPNSConnection.post notif, @certificate, @options
         end
       end
     end

--- a/lib/ruby-push-notifications/mpns/mpns_pusher.rb
+++ b/lib/ruby-push-notifications/mpns/mpns_pusher.rb
@@ -9,7 +9,9 @@ module RubyPushNotifications
       # Initializes the MPNSPusher
       #
       # @param certificate [String]. The PEM encoded MPNS certificate.
-      # @param optional options [Hash]. Options for the HTTP connection.
+      # @param options [Hash] optional. Options for GCMPusher. Currently supports:
+      #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
+      #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       # (http://msdn.microsoft.com/pt-br/library/windows/apps/ff941099)
       def initialize(certificate = nil, options = {})
         @certificate = certificate

--- a/lib/ruby-push-notifications/version.rb
+++ b/lib/ruby-push-notifications/version.rb
@@ -1,3 +1,3 @@
 module RubyPushNotifications
-  VERSION = '0.5.0'
+  VERSION = '1.0.0'
 end

--- a/lib/ruby-push-notifications/version.rb
+++ b/lib/ruby-push-notifications/version.rb
@@ -1,3 +1,3 @@
 module RubyPushNotifications
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/ruby-push-notifications.gemspec
+++ b/ruby-push-notifications.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/calonso/ruby-push-notifications'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/spec/ruby-push-notifications/apns/apns_connection_spec.rb
+++ b/spec/ruby-push-notifications/apns/apns_connection_spec.rb
@@ -4,17 +4,17 @@ module RubyPushNotifications
     describe APNSConnection do
 
       let(:cert) { File.read 'spec/support/dummy.pem' }
-      let(:tcp_socket) { instance_double(TCPSocket).as_null_object }
+      let(:tcp_socket) { instance_double(Socket).as_null_object }
       let(:ssl_socket) { instance_double(OpenSSL::SSL::SSLSocket).as_null_object }
 
       describe '::open' do
         before do
-          allow(TCPSocket).to receive(:new).with('gateway.sandbox.push.apple.com', 2195).and_return tcp_socket
+          allow(Socket).to receive(:tcp).with('gateway.sandbox.push.apple.com', 2195, nil, nil, { connect_timeout: 30 }).and_return tcp_socket
           allow(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, an_instance_of(OpenSSL::SSL::SSLContext)).and_return ssl_socket
         end
 
         it 'creates the connection' do
-          expect(TCPSocket).to receive(:new).with('gateway.sandbox.push.apple.com', 2195).and_return tcp_socket
+          expect(Socket).to receive(:tcp).with('gateway.sandbox.push.apple.com', 2195, nil, nil, { connect_timeout: 30 }).and_return tcp_socket
           expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, an_instance_of(OpenSSL::SSL::SSLContext)).and_return ssl_socket
           APNSConnection.open cert, true
         end

--- a/spec/ruby-push-notifications/apns/apns_pusher_spec.rb
+++ b/spec/ruby-push-notifications/apns/apns_pusher_spec.rb
@@ -9,7 +9,7 @@ module RubyPushNotifications
       let(:data) { { a: 1 } }
 
       before do
-        allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil).and_return connection
+        allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil, {}).and_return connection
       end
 
       describe '#push' do
@@ -93,7 +93,7 @@ module RubyPushNotifications
               let(:connection2) { instance_double(APNSConnection).as_null_object }
 
               before do
-                allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil).and_return connection, connection2
+                allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil, {}).and_return connection, connection2
               end
 
               context 'failing first' do
@@ -197,7 +197,7 @@ module RubyPushNotifications
                 allow(connection).to receive(:read).with(6).and_return [8, PROCESSING_ERROR_STATUS_CODE, 0].pack('ccN')
                 allow(connection2).to receive(:read).with(6).and_return [8, MISSING_DEVICE_TOKEN_STATUS_CODE, 2].pack('ccN')
                 allow(connection3).to receive(:read).with(6).and_return [8, INVALID_TOPIC_SIZE_STATUS_CODE, 9].pack('ccN')
-                allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil).and_return connection, connection2, connection3, connection4
+                allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil, {}).and_return connection, connection2, connection3, connection4
               end
 
               it 'reopens the connection' do
@@ -249,7 +249,7 @@ module RubyPushNotifications
                 allow(connection).to receive(:read).with(6).and_return [8, PROCESSING_ERROR_STATUS_CODE, 0].pack('ccN')
                 allow(connection2).to receive(:read).with(6).and_return [8, MISSING_DEVICE_TOKEN_STATUS_CODE, 2].pack('ccN')
                 allow(connection3).to receive(:read).with(6).and_return [8, INVALID_TOPIC_SIZE_STATUS_CODE, 9].pack('ccN')
-                allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil).and_return connection, connection2, connection3, connection4
+                allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil, {}).and_return connection, connection2, connection3, connection4
               end
 
               it 'repones the connection' do

--- a/spec/ruby-push-notifications/apns/apns_pusher_spec.rb
+++ b/spec/ruby-push-notifications/apns/apns_pusher_spec.rb
@@ -200,7 +200,7 @@ module RubyPushNotifications
                 allow(APNSConnection).to receive(:open).with(certificate, sandbox, nil).and_return connection, connection2, connection3, connection4
               end
 
-              it 'repones the connection' do
+              it 'reopens the connection' do
                 (0..2).each do |i|
                   expect(connection).to receive(:write).with(apns_binary(data, tokens[i], i)).once
                 end


### PR DESCRIPTION
Hello!

This PR addresses problem we've faced a bunch of time in production, where we've had Sidekiq workers that get stuck sending notifications.
Since no timeout is provided, the job stays stuck until the next worker restart, at which point the notification has long since become useless.

Technically the change wasn't necessary for APNS, but this way the signature of each `XYZPusher` initializer is consistent and timeout is always configurable.

