### PR TITLE
Make it possible to set a custom GCM endpoint..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrealeased] - [unrealease date]
-- **Added**: Option (`gcm_url`) to set custom GCM endpoint (Android)
-- **Added**: Option (`apns_host`) to set custom APNS environment (iOS)
+- **Added**: Option (`url`) to set custom GCM endpoint (Android)
+- **Added**: Option (`host`) to set custom APNS environment (iOS)
 
 ## 1.0.1 - 2017-01-12
 - **Fixed**: Loading issue when `'forwardable'` wasn't previously required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrealeased] - [unrealease date]
+- **Added**: Option (`gcm_url`) to set custom GCM endpoint
 
 ## 1.0.1 - 2017-01-12
 - **Fixed**: Loading issue when `'forwardable'` wasn't previously required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrealeased] - [unrealease date]
 - **Added**: Option (`gcm_url`) to set custom GCM endpoint (Android)
+- **Added**: Option (`apns_url`) to set custom APNS endpoint (iOS)
 
 ## 1.0.1 - 2017-01-12
 - **Fixed**: Loading issue when `'forwardable'` wasn't previously required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrealeased] - [unrealease date]
 - **Added**: Option (`gcm_url`) to set custom GCM endpoint (Android)
-- **Added**: Option (`apns_url`) to set custom APNS endpoint (iOS)
+- **Added**: Option (`apns_host`) to set custom APNS environment (iOS)
 
 ## 1.0.1 - 2017-01-12
 - **Fixed**: Loading issue when `'forwardable'` wasn't previously required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrealeased] - [unrealease date]
-- **Added**: Option (`gcm_url`) to set custom GCM endpoint
+- **Added**: Option (`gcm_url`) to set custom GCM endpoint (Android)
 
 ## 1.0.1 - 2017-01-12
 - **Fixed**: Loading issue when `'forwardable'` wasn't previously required.

--- a/examples/apns.rb
+++ b/examples/apns.rb
@@ -16,8 +16,8 @@ pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/ap
 # Connect timeout defaults to 30s
 # pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { connect_timeout: 20 })
 
-# Manually set APNS URL (e.g. useful for load testing)
-# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { apns_url: "gateway.push.example.com" })
+# Manually set APNS environment (e.g. useful for load testing)
+# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { apns_host: "gateway.push.example.com" })
 
 pusher.push [notification]
 p 'Notification sending results:'

--- a/examples/apns.rb
+++ b/examples/apns.rb
@@ -16,6 +16,9 @@ pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/ap
 # Connect timeout defaults to 30s
 # pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { connect_timeout: 20 })
 
+# Manually set APNS URL (e.g. useful for load testing)
+# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { apns_url: "gateway.push.example.com" })
+
 pusher.push [notification]
 p 'Notification sending results:'
 p "Success: #{notification.success}, Failed: #{notification.failed}"

--- a/examples/apns.rb
+++ b/examples/apns.rb
@@ -17,7 +17,7 @@ pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/ap
 # pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { connect_timeout: 20 })
 
 # Manually set APNS environment (e.g. useful for load testing)
-# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { apns_host: "gateway.push.example.com" })
+# pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { host: "gateway.push.example.com" })
 
 pusher.push [notification]
 p 'Notification sending results:'

--- a/examples/apns.rb
+++ b/examples/apns.rb
@@ -17,6 +17,7 @@ pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/ap
 # pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { connect_timeout: 20 })
 
 # Manually set APNS environment (e.g. useful for load testing)
+# When option `host` is given it always uses this environment, `sandbox` param is ignored.
 # pusher = RubyPushNotifications::APNS::APNSPusher.new(File.read('/path/to/your/apps/certificate.pem'), true, password, { host: "gateway.push.example.com" })
 
 pusher.push [notification]

--- a/examples/gcm.rb
+++ b/examples/gcm.rb
@@ -15,6 +15,9 @@ pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key"
 # Open and read timeouts default to 30s
 # pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { open_timeout: 10, read_timeout: 10 }
 
+# Use a custom GCM endpoint (e.g. useful for load testing)
+# pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { gcm_url: "https://example.com/gcm/send" }
+
 pusher.push [notification]
 p 'Notification sending results:'
 p "Success: #{notification.success}, Failed: #{notification.failed}"

--- a/examples/gcm.rb
+++ b/examples/gcm.rb
@@ -16,7 +16,7 @@ pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key"
 # pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { open_timeout: 10, read_timeout: 10 }
 
 # Manually set GCM URL (e.g. useful for load testing)
-# pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { gcm_url: "https://example.com/gcm/send" }
+# pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { url: "https://example.com/gcm/send" }
 
 pusher.push [notification]
 p 'Notification sending results:'

--- a/examples/gcm.rb
+++ b/examples/gcm.rb
@@ -15,7 +15,7 @@ pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key"
 # Open and read timeouts default to 30s
 # pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { open_timeout: 10, read_timeout: 10 }
 
-# Use a custom GCM endpoint (e.g. useful for load testing)
+# Manually set GCM URL (e.g. useful for load testing)
 # pusher = RubyPushNotifications::GCM::GCMPusher.new "Your app's GCM key", { gcm_url: "https://example.com/gcm/send" }
 
 pusher.push [notification]

--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -26,7 +26,7 @@ module RubyPushNotifications
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
       # @param pass [String] optional. Passphrase for the certificate.
       # @param options [Hash] optional. Options for #open. Currently supports:
-      #   * apns_host [String]: Hostname of the APNS environment. Defaults to the official APNS hostname.
+      #   * host [String]: Hostname of the APNS environment. Defaults to the official APNS hostname.
       #   * connect_timeout [Integer]: how long the socket will wait for when opening the APNS socket. Defaults to 30.
       # @return [APNSConnection]. The recently stablished connection.
       def self.open(cert, sandbox, pass = nil, options = {})
@@ -34,7 +34,7 @@ module RubyPushNotifications
         ctx.key = OpenSSL::PKey::RSA.new cert, pass
         ctx.cert = OpenSSL::X509::Certificate.new cert
 
-        h = options.fetch(:apns_host, host(sandbox))
+        h = options.fetch(:host, host(sandbox))
         socket = Socket.tcp h, APNS_PORT, nil, nil, connect_timeout: options.fetch(:connect_timeout, 30)
         ssl = OpenSSL::SSL::SSLSocket.new socket, ctx
         ssl.connect

--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -26,7 +26,7 @@ module RubyPushNotifications
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
       # @param pass [String] optional. Passphrase for the certificate.
       # @param options [Hash] optional. Options for #open. Currently supports:
-      #   * apns_url [String]: The URL of the APNS environment. Defaults to the official APNS URL.
+      #   * apns_host [String]: Hostname of the APNS environment. Defaults to the official APNS hostname.
       #   * connect_timeout [Integer]: how long the socket will wait for when opening the APNS socket. Defaults to 30.
       # @return [APNSConnection]. The recently stablished connection.
       def self.open(cert, sandbox, pass = nil, options = {})
@@ -34,7 +34,7 @@ module RubyPushNotifications
         ctx.key = OpenSSL::PKey::RSA.new cert, pass
         ctx.cert = OpenSSL::X509::Certificate.new cert
 
-        h = options.fetch(:apns_url, host(sandbox))
+        h = options.fetch(:apns_host, host(sandbox))
         socket = Socket.tcp h, APNS_PORT, nil, nil, connect_timeout: options.fetch(:connect_timeout, 30)
         ssl = OpenSSL::SSL::SSLSocket.new socket, ctx
         ssl.connect

--- a/lib/ruby-push-notifications/apns/apns_connection.rb
+++ b/lib/ruby-push-notifications/apns/apns_connection.rb
@@ -26,6 +26,7 @@ module RubyPushNotifications
       # @param sandbox [Boolean]. Whether to use the sandbox environment or not.
       # @param pass [String] optional. Passphrase for the certificate.
       # @param options [Hash] optional. Options for #open. Currently supports:
+      #   * apns_url [String]: The URL of the APNS environment. Defaults to the official APNS URL.
       #   * connect_timeout [Integer]: how long the socket will wait for when opening the APNS socket. Defaults to 30.
       # @return [APNSConnection]. The recently stablished connection.
       def self.open(cert, sandbox, pass = nil, options = {})
@@ -33,7 +34,7 @@ module RubyPushNotifications
         ctx.key = OpenSSL::PKey::RSA.new cert, pass
         ctx.cert = OpenSSL::X509::Certificate.new cert
 
-        h = host sandbox
+        h = options.fetch(:apns_url, host(sandbox))
         socket = Socket.tcp h, APNS_PORT, nil, nil, connect_timeout: options.fetch(:connect_timeout, 30)
         ssl = OpenSSL::SSL::SSLSocket.new socket, ctx
         ssl.connect

--- a/lib/ruby-push-notifications/apns/apns_pusher.rb
+++ b/lib/ruby-push-notifications/apns/apns_pusher.rb
@@ -16,6 +16,7 @@ module RubyPushNotifications
       # @param certificate [String]. The PEM encoded APNS certificate.
       # @param sandbox [Boolean]. Whether the certificate is an APNS sandbox or not.
       # @param options [Hash] optional. Options for APNSPusher. Currently supports:
+      #   * apns_url [String]: The URL of the APNS environment. Defaults to the official APNS URL.
       #   * connect_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       def initialize(certificate, sandbox, password = nil, options = {})
         @certificate = certificate

--- a/lib/ruby-push-notifications/apns/apns_pusher.rb
+++ b/lib/ruby-push-notifications/apns/apns_pusher.rb
@@ -16,7 +16,7 @@ module RubyPushNotifications
       # @param certificate [String]. The PEM encoded APNS certificate.
       # @param sandbox [Boolean]. Whether the certificate is an APNS sandbox or not.
       # @param options [Hash] optional. Options for APNSPusher. Currently supports:
-      #   * apns_url [String]: The URL of the APNS environment. Defaults to the official APNS URL.
+      #   * apns_host [String]: Hostname of the APNS environment. Defaults to the official APNS hostname.
       #   * connect_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       def initialize(certificate, sandbox, password = nil, options = {})
         @certificate = certificate

--- a/lib/ruby-push-notifications/apns/apns_pusher.rb
+++ b/lib/ruby-push-notifications/apns/apns_pusher.rb
@@ -16,7 +16,7 @@ module RubyPushNotifications
       # @param certificate [String]. The PEM encoded APNS certificate.
       # @param sandbox [Boolean]. Whether the certificate is an APNS sandbox or not.
       # @param options [Hash] optional. Options for APNSPusher. Currently supports:
-      #   * apns_host [String]: Hostname of the APNS environment. Defaults to the official APNS hostname.
+      #   * host [String]: Hostname of the APNS environment. Defaults to the official APNS hostname.
       #   * connect_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       def initialize(certificate, sandbox, password = nil, options = {})
         @certificate = certificate

--- a/lib/ruby-push-notifications/gcm/gcm_connection.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_connection.rb
@@ -28,6 +28,7 @@ module RubyPushNotifications
       # @param key [String]. The GCM sender id to use
       #    (https://developer.android.com/google/gcm/gcm.html#senderid)
       # @param options [Hash] optional. Options for #post. Currently supports:
+      #   * gcm_url [String]: The URL of the Android GCM endpoint
       #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       # @return [GCMResponse]. The GCMResponse that encapsulates the received response
@@ -37,7 +38,7 @@ module RubyPushNotifications
             AUTHORIZATION_HEADER => "key=#{key}"
         }
 
-        url = URI.parse GCM_URL
+        url = URI.parse options.fetch(:gcm_url, GCM_URL)
         http = Net::HTTP.new url.host, url.port
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/ruby-push-notifications/gcm/gcm_connection.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_connection.rb
@@ -28,7 +28,7 @@ module RubyPushNotifications
       # @param key [String]. The GCM sender id to use
       #    (https://developer.android.com/google/gcm/gcm.html#senderid)
       # @param options [Hash] optional. Options for #post. Currently supports:
-      #   * gcm_url [String]: The URL of the Android GCM endpoint
+      #   * gcm_url [String]: The URL of the Android GCM endpoint. Defaults to the official GCM URL.
       #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       # @return [GCMResponse]. The GCMResponse that encapsulates the received response

--- a/lib/ruby-push-notifications/gcm/gcm_connection.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_connection.rb
@@ -28,7 +28,7 @@ module RubyPushNotifications
       # @param key [String]. The GCM sender id to use
       #    (https://developer.android.com/google/gcm/gcm.html#senderid)
       # @param options [Hash] optional. Options for #post. Currently supports:
-      #   * gcm_url [String]: The URL of the Android GCM endpoint. Defaults to the official GCM URL.
+      #   * url [String]: URL of the GCM endpoint. Defaults to the official GCM URL.
       #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       # @return [GCMResponse]. The GCMResponse that encapsulates the received response
@@ -38,7 +38,7 @@ module RubyPushNotifications
             AUTHORIZATION_HEADER => "key=#{key}"
         }
 
-        url = URI.parse options.fetch(:gcm_url, GCM_URL)
+        url = URI.parse options.fetch(:url, GCM_URL)
         http = Net::HTTP.new url.host, url.port
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/ruby-push-notifications/gcm/gcm_connection.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_connection.rb
@@ -40,7 +40,7 @@ module RubyPushNotifications
 
         url = URI.parse options.fetch(:url, GCM_URL)
         http = Net::HTTP.new url.host, url.port
-        http.use_ssl = true
+        http.use_ssl = url.scheme == 'https'
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         http.open_timeout = options.fetch(:open_timeout, 30)
         http.read_timeout = options.fetch(:read_timeout, 30)

--- a/lib/ruby-push-notifications/gcm/gcm_pusher.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_pusher.rb
@@ -12,7 +12,7 @@ module RubyPushNotifications
       # @param key [String]. GCM sender id to use
       #   ((https://developer.android.com/google/gcm/gcm.html#senderid))
       # @param options [Hash] optional. Options for GCMPusher. Currently supports:
-      #   * gcm_url [String]: The URL of the Android GCM endpoint
+      #   * url [String]: URL of the GCM endpoint. Defaults to the official GCM URL.
       #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       def initialize(key, options = {})

--- a/lib/ruby-push-notifications/gcm/gcm_pusher.rb
+++ b/lib/ruby-push-notifications/gcm/gcm_pusher.rb
@@ -12,6 +12,7 @@ module RubyPushNotifications
       # @param key [String]. GCM sender id to use
       #   ((https://developer.android.com/google/gcm/gcm.html#senderid))
       # @param options [Hash] optional. Options for GCMPusher. Currently supports:
+      #   * gcm_url [String]: The URL of the Android GCM endpoint
       #   * open_timeout [Integer]: Number of seconds to wait for the connection to open. Defaults to 30.
       #   * read_timeout [Integer]: Number of seconds to wait for one block to be read. Defaults to 30.
       def initialize(key, options = {})

--- a/spec/ruby-push-notifications/apns/apns_connection_spec.rb
+++ b/spec/ruby-push-notifications/apns/apns_connection_spec.rb
@@ -28,6 +28,13 @@ module RubyPushNotifications
           expect(OpenSSL::PKey::RSA).to receive(:new).with(cert, 'password')
           expect(APNSConnection.open(cert, true, 'password')).to be_a APNSConnection
         end
+
+        context 'when :apns_url option is present' do
+          it 'opens a connection with a custom APNS' do
+            expect(Socket).to receive(:tcp).with('gateway.push.example.com', 2195, nil, nil, { connect_timeout: 30 }).and_return tcp_socket
+            APNSConnection.open cert, true, 'password', { apns_url: "gateway.push.example.com" }
+          end
+        end
       end
 
       describe '#close' do

--- a/spec/ruby-push-notifications/apns/apns_connection_spec.rb
+++ b/spec/ruby-push-notifications/apns/apns_connection_spec.rb
@@ -29,10 +29,10 @@ module RubyPushNotifications
           expect(APNSConnection.open(cert, true, 'password')).to be_a APNSConnection
         end
 
-        context 'when :apns_host option is present' do
+        context 'when :host option is present' do
           it 'opens a connection with a custom APNS' do
             expect(Socket).to receive(:tcp).with('gateway.push.example.com', 2195, nil, nil, { connect_timeout: 30 }).and_return tcp_socket
-            APNSConnection.open cert, true, 'password', { apns_host: "gateway.push.example.com" }
+            APNSConnection.open cert, true, 'password', { host: "gateway.push.example.com" }
           end
         end
       end

--- a/spec/ruby-push-notifications/apns/apns_connection_spec.rb
+++ b/spec/ruby-push-notifications/apns/apns_connection_spec.rb
@@ -29,10 +29,10 @@ module RubyPushNotifications
           expect(APNSConnection.open(cert, true, 'password')).to be_a APNSConnection
         end
 
-        context 'when :apns_url option is present' do
+        context 'when :apns_host option is present' do
           it 'opens a connection with a custom APNS' do
             expect(Socket).to receive(:tcp).with('gateway.push.example.com', 2195, nil, nil, { connect_timeout: 30 }).and_return tcp_socket
-            APNSConnection.open cert, true, 'password', { apns_url: "gateway.push.example.com" }
+            APNSConnection.open cert, true, 'password', { apns_host: "gateway.push.example.com" }
           end
         end
       end

--- a/spec/ruby-push-notifications/gcm/gcm_connection_spec.rb
+++ b/spec/ruby-push-notifications/gcm/gcm_connection_spec.rb
@@ -23,12 +23,12 @@ module RubyPushNotifications
                 once
         end
 
-        context 'when :gcm_url option is present' do
+        context 'when :url option is present' do
           it 'posts data to a custom GCM endpoint' do
             stub_request(:post, 'https://example.com/gcm/send').
               to_return status: [200, 'OK'], body: response
 
-            GCMConnection.post body, key, gcm_url: 'https://example.com/gcm/send'
+            GCMConnection.post body, key, url: 'https://example.com/gcm/send'
 
             expect(WebMock).
               to have_requested(:post, 'https://example.com/gcm/send').

--- a/spec/ruby-push-notifications/gcm/gcm_connection_spec.rb
+++ b/spec/ruby-push-notifications/gcm/gcm_connection_spec.rb
@@ -14,13 +14,31 @@ module RubyPushNotifications
             to_return status: [200, 'OK'], body: response
         end
 
-        it 'runs the right request' do
-          GCMConnection.post body, key
+        context 'without optional params' do
+          it 'runs the right request' do
+            GCMConnection.post body, key
 
-          expect(WebMock).
-            to have_requested(:post, 'https://android.googleapis.com/gcm/send').
-              with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
-                once
+            expect(WebMock).
+              to have_requested(:post, 'https://android.googleapis.com/gcm/send').
+                with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
+                  once
+          end
+        end
+
+        context 'with optional params' do
+          context 'when :gcm_url is present' do
+            it 'posts data to a custom GCM endpoint' do
+              stub_request(:post, 'https://example.com/gcm/send').
+                to_return status: [200, 'OK'], body: response
+
+              GCMConnection.post body, key, gcm_url: 'https://example.com/gcm/send'
+
+              expect(WebMock).
+                to have_requested(:post, 'https://example.com/gcm/send').
+                  with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
+                    once
+            end
+          end
         end
 
         it 'returns the response encapsulated in a GCMResponse object' do

--- a/spec/ruby-push-notifications/gcm/gcm_connection_spec.rb
+++ b/spec/ruby-push-notifications/gcm/gcm_connection_spec.rb
@@ -14,30 +14,26 @@ module RubyPushNotifications
             to_return status: [200, 'OK'], body: response
         end
 
-        context 'without optional params' do
-          it 'runs the right request' do
-            GCMConnection.post body, key
+        it 'runs the right request' do
+          GCMConnection.post body, key
 
-            expect(WebMock).
-              to have_requested(:post, 'https://android.googleapis.com/gcm/send').
-                with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
-                  once
-          end
+          expect(WebMock).
+            to have_requested(:post, 'https://android.googleapis.com/gcm/send').
+              with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
+                once
         end
 
-        context 'with optional params' do
-          context 'when :gcm_url is present' do
-            it 'posts data to a custom GCM endpoint' do
-              stub_request(:post, 'https://example.com/gcm/send').
-                to_return status: [200, 'OK'], body: response
+        context 'when :gcm_url option is present' do
+          it 'posts data to a custom GCM endpoint' do
+            stub_request(:post, 'https://example.com/gcm/send').
+              to_return status: [200, 'OK'], body: response
 
-              GCMConnection.post body, key, gcm_url: 'https://example.com/gcm/send'
+            GCMConnection.post body, key, gcm_url: 'https://example.com/gcm/send'
 
-              expect(WebMock).
-                to have_requested(:post, 'https://example.com/gcm/send').
-                  with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
-                    once
-            end
+            expect(WebMock).
+              to have_requested(:post, 'https://example.com/gcm/send').
+                with(body: body, headers: { 'Content-Type' => 'application/json', 'Authorization' => "key=#{key}" }).
+                  once
           end
         end
 


### PR DESCRIPTION
Use case:

A company wants to do some load testing without actually sending data to
a real GCM.